### PR TITLE
increase length of short_message

### DIFF
--- a/R/engineer-features-base.R
+++ b/R/engineer-features-base.R
@@ -13,7 +13,7 @@ add_attributes_detailed <- function(log) {
   mutate_(log,
     date = ~ymd_hms(paste(year, month, monthday, time)),
     short_hash = ~substr(hash, 1, 4),
-    short_message = ~substr(message, 1, 20),
+    short_message = ~substr(message, 1, 50),
     short_description = ~ifelse(!is.na(message),
                                 substr(description, 1, 20), NA
     ),


### PR DESCRIPTION
Can we get at least 50 chr? That's when GitHub says the commit message is going from short to long: "Great commit summaries contain fewer than 50 characters". I'm using this pkg to analyse a git repo and some of key details are the last 30 chrs, so it would be great to get a few more chrs from the parse_log_detailed fn. Thanks!

Edit: I see now there is also a variable 'message' which has the longer commit message, so perhaps it doesn't really matter how many characters are in the short_message. Up to you!